### PR TITLE
Make GeoFireCollectionRef generic

### DIFF
--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -65,7 +65,7 @@ describe('RxGeofire', () => {
   });
 
   describe('CollectionRef', () => {
-    let ref: GeoFireCollectionRef;
+    let ref: GeoFireCollectionRef<any>;
     let hash;
     let phx;
     beforeEach(() => {

--- a/spec/main.spec.ts
+++ b/spec/main.spec.ts
@@ -69,7 +69,7 @@ describe('RxGeofire', () => {
     let hash;
     let phx;
     beforeEach(() => {
-      ref = gfx.collection('cities');
+      ref = gfx.collection<any>('cities');
       hash = gfx.point(33.45, -112.1);
       phx = { id: 'phoenix', name: 'Phoenix, AZ', position: hash.data };
     });
@@ -88,7 +88,7 @@ describe('RxGeofire', () => {
     });
 
     test('should filter docs with a query and be able to change its query', done => {
-      ref = gfx.collection('cities', ref =>
+      ref = gfx.collection<any>('cities', ref =>
         ref.where('name', '==', 'Austin, TX')
       );
 
@@ -158,12 +158,12 @@ describe('RxGeofire', () => {
     let ref: GeoFireCollectionRef;
     let center;
     beforeEach(() => {
-      ref = gfx.collection('bearings');
+      ref = gfx.collection<any>('bearings');
       center = gfx.point(40.5, -80.0);
     });
 
     test('work with compound Firestore queries', async done => {
-      const ref = gfx.collection('compound', ref =>
+      const ref = gfx.collection<any>('compound', ref =>
         ref.where('color', '==', 'blue')
       );
       const point = gfx.point(38, -119);
@@ -239,7 +239,7 @@ describe('RxGeofire', () => {
     let center;
     let data;
     beforeAll(async () => {
-      ref = gfx.collection('bearings');
+      ref = gfx.collection<any>('bearings');
       center = gfx.point(40.5, -80.0);
       data = await get(ref.within(center, 5, 'pos'));
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,7 +12,7 @@ export class GeoFireClient {
    * @param  {QueryFn} query? Firestore query id ref => ref.orderBy('foo').limit(5)
    * @returns {GeoFireCollectionRef}
    */
-  collection(path: string, query?: QueryFn): GeoFireCollectionRef {
+  collection<T>(path: string, query?: QueryFn): GeoFireCollectionRef<T> {
     return new GeoFireCollectionRef(this.app, path, query);
   }
   /**

--- a/src/collection.ts
+++ b/src/collection.ts
@@ -19,11 +19,10 @@ export interface QueryMetadata {
 }
 
 export interface GeoQueryDocument {
-  [key: string]: any;
   queryMetadata: QueryMetadata;
 }
 
-export class GeoFireCollectionRef {
+export class GeoFireCollectionRef<T> {
   private ref: firestore.CollectionReference;
   private query: firestore.Query;
   private stream: Observable<firestore.QuerySnapshot>;
@@ -120,7 +119,7 @@ export class GeoFireCollectionRef {
     radius: number,
     field: string,
     opts = defaultOpts
-  ): Observable<GeoQueryDocument[]> {
+  ): Observable<(GeoQueryDocument & T)[]> {
     const precision = setPrecsion(radius);
     const centerHash = center.hash.substr(0, precision);
     const area = GeoFirePoint.neighbors(centerHash).concat(centerHash);
@@ -147,7 +146,7 @@ export class GeoFireCollectionRef {
               distance: center.distance(lat, lng),
               bearing: center.bearing(lat, lng)
             };
-            return { ...val, queryMetadata };
+            return { ...val, queryMetadata } as (GeoQueryDocument & T);
           })
 
           .sort((a, b) => a.queryMetadata.distance - b.queryMetadata.distance);


### PR DESCRIPTION
This adds the possibility to supply a type to the reference, which improves the compiler hints when accessing properties