### PR TITLE
Support firebase ^8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "license": "ISC",
     "peerDependencies": {
         "firebase": "^8.3.2",
-        "rxjs": "^6.2.1"
+        "rxjs": "^6.6.7"
     },
     "devDependencies": {
         "@firebase/firestore-types": "^0.4.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "author": "Jeff Delaney",
     "license": "ISC",
     "peerDependencies": {
-        "firebase": "^7.2.0",
+        "firebase": "^8.3.2",
         "rxjs": "^6.2.1"
     },
     "devDependencies": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,10 +3,12 @@ import { FirebaseSDK } from './interfaces';
 import { GeoFireQuery } from './query';
 import { encode, distance, bearing } from './util';
 
-import * as fb from 'firebase/app';
+import firebase from 'firebase/app';
+import 'firebase/firestore';
+
 
 export interface FirePoint {
-  geopoint: fb.firestore.GeoPoint,
+  geopoint: firebase.firestore.GeoPoint,
   geohash: string
 }
 
@@ -32,7 +34,7 @@ export class GeoFireClient {
       geopoint: new (this.app as any).firestore.GeoPoint(
         latitude,
         longitude
-      ) as fb.firestore.GeoPoint,
+      ) as firebase.firestore.GeoPoint,
       geohash: encode(latitude, longitude, 9)
     }
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,11 +1,12 @@
-import * as fb from 'firebase/app';
+import firebase from 'firebase/app';
+import 'firebase/firestore';
 
 /**
  * Represents Firebase JS (Web) or Firebase Admin (Node)
  * Web ES6 example: import firebase from 'firebase/app'
  * Cloud Functions example: const admin = require('firebase-amdin')
  */
-export type FirebaseSDK = typeof fb;
+export type FirebaseSDK = typeof firebase;
 
 export type Latitude = number;
 export type Longitude = number;

--- a/src/query.ts
+++ b/src/query.ts
@@ -12,13 +12,14 @@ import {
 import { FeatureCollection, Geometry } from './interfaces';
 import { neighbors, toGeoJSONFeature, distance, bearing, setPrecision } from './util';
 
-import * as fb from 'firebase/app';
+import firebase from 'firebase/app';
+import 'firebase/firestore';
 import { FirebaseSDK } from './interfaces';
 import { FirePoint } from './client';
 
 export type QueryFn = (
-  ref: fb.firestore.CollectionReference
-) => fb.firestore.Query;
+  ref: firebase.firestore.CollectionReference
+) => firebase.firestore.Query;
 
 export interface GeoQueryOptions {
   units?: 'km';
@@ -38,7 +39,7 @@ export interface GeoQueryDocument {
 export class GeoFireQuery<T = any> {
   constructor(
     private app: FirebaseSDK,
-    private ref?: fb.firestore.CollectionReference | fb.firestore.Query | string
+    private ref?: firebase.firestore.CollectionReference | firebase.firestore.Query | string
   ) {
     if (typeof ref === 'string') {
       this.ref = this.app.firestore().collection(ref);
@@ -132,7 +133,7 @@ export class GeoFireQuery<T = any> {
 
   private queryPoint(geohash: string, field: string) {
     const end = geohash + '~';
-    return (this.ref as fb.firestore.CollectionReference)
+    return (this.ref as firebase.firestore.CollectionReference)
       .orderBy(`${field}.geohash`)
       .startAt(geohash)
       .endAt(end);
@@ -153,7 +154,7 @@ export class GeoFireQuery<T = any> {
 }
 
 function snapToData(id = 'id') {
-  return map((querySnapshot: fb.firestore.QuerySnapshot) =>
+  return map((querySnapshot: firebase.firestore.QuerySnapshot) =>
     querySnapshot.docs.map(v => {
       return {
         ...(id ? { [id]: v.id } : null),


### PR DESCRIPTION
### What changed

- firebase upgraded from `^7.2.0` to `^8.3.2`
- rxjs upgraded from `^6.2.1`  to `^6.6.7`
- Import only the `firestore` service into the `firebase` namespace